### PR TITLE
Dockerfile: fix target paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM httpd:2.4
-COPY ./dist/awesomenauts-drafter/ /user/local/apache2/htdocs/
-COPY ./httpd.conf /user/local/apache2/conf/httpd.conf
+COPY ./dist/awesomenauts-drafter/ /usr/local/apache2/htdocs/
+COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
This looks like `user` was a typo for `usr`; [the documentation](https://hub.docker.com/_/httpd) contains examples like:

```
COPY ./public-html/ /usr/local/apache2/htdocs/
COPY ./my-httpd.conf /usr/local/apache2/conf/httpd.conf
```